### PR TITLE
Fixes a crash when navigating to data tab

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,8 +57,8 @@ android {
 dependencies {
 
     // https://developer.android.com/jetpack/androidx/releases/core
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.core:core-splashscreen:1.0.0-beta02'
+    implementation 'androidx.core:core-ktx:1.8.0'
+    implementation 'androidx.core:core-splashscreen:1.0.0-rc01'
     //implementation 'androidx.appcompat:appcompat:1.3.0'
     // https://github.com/material-components/material-components-android/releases
     implementation 'com.google.android.material:material:1.6.0-beta01'
@@ -76,16 +76,16 @@ dependencies {
     // https://developer.android.com/jetpack/androidx/releases/activity
     implementation 'androidx.activity:activity-compose:1.4.0'
     // https://github.com/Kotlin/kotlinx.coroutines/releases
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'
     // https://developer.android.com/jetpack/androidx/releases/navigation
     // Do no upgrade to 2.5.0-alpha versions specifically alpha02/03 for a known issue see below.
     // https://stackoverflow.com/questions/71361999/jetpack-compose-bottomnavigation-java-lang-
     // illegalstateexception-already-atta
-    implementation 'androidx.navigation:navigation-compose:2.4.1'
-    implementation 'io.coil-kt:coil-compose:2.0.0-rc02'
+    implementation 'androidx.navigation:navigation-compose:2.4.2'
+    implementation 'io.coil-kt:coil-compose:2.1.0'
 
     // https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.1'
     // Paging 3 - https://developer.android.com/jetpack/androidx/releases/paging
     implementation 'androidx.paging:paging-compose:1.0.0-alpha14'
 
@@ -125,14 +125,14 @@ dependencies {
 
     // So google decided to remove coil from accompanist version 0.16.0 onwards
     // https://coil-kt.github.io/coil/compose/#migrating-from-accompanist
-    implementation("io.coil-kt:coil-compose:1.3.2")
+    implementation('io.coil-kt:coil-compose:2.1.0')
 
     implementation 'com.google.accompanist:accompanist-systemuicontroller:0.20.0'
     implementation "com.google.accompanist:accompanist-permissions:$accompanist_version"
     implementation "com.google.accompanist:accompanist-swiperefresh:$accompanist_version"
     implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
     implementation "com.google.accompanist:accompanist-pager-indicators:$accompanist_version"
-    implementation('org.jetbrains.kotlinx:kotlinx-datetime:0.3.2')
+    implementation('org.jetbrains.kotlinx:kotlinx-datetime:0.3.3')
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,11 @@
 buildscript {
     ext {
         // https://developer.android.com/jetpack/androidx/releases/compose
-        compose_version = '1.2.0-alpha06'
+        compose_version = '1.2.0-beta03'
         // https://developer.android.com/jetpack/compose/setup#configure_kotlin
-        kotlin_version = '1.6.10'
+        kotlin_version = '1.6.21'
         // https://github.com/google/dagger/releases
-        hilt_dagger_version = '2.41'
+        hilt_dagger_version = '2.42'
         // https://developer.android.com/training/dependency-injection/hilt-android
         hilt_android_version = '1.0.0'
         // https://github.com/google/accompanist/releases
@@ -14,14 +14,14 @@ buildscript {
         // https://github.com/google/accompanist/releases
         accompanist_version = '0.20.0'
         // https://developer.android.com/jetpack/androidx/releases/lifecycle#kotlin
-        lifecycle_version = '2.5.0-alpha05'
+        lifecycle_version = '2.5.0-rc01'
     }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0-rc02'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_dagger_version"
     }


### PR DESCRIPTION
* Fixes a crash when navigating to data tab after renaming a device. This seemed to be caused by an alpha version of Jetpack compose. Hence the Gradle dependency bump.