### PR TITLE
Bugfix: IDs grew too big to fit into Int

### DIFF
--- a/app/src/main/java/no/nordicsemi/android/ei/model/Sample.kt
+++ b/app/src/main/java/no/nordicsemi/android/ei/model/Sample.kt
@@ -9,7 +9,7 @@
 package no.nordicsemi.android.ei.model
 
 data class Sample(
-    val id: Int,
+    val id: Long,
     val filename: String,
     val signatureValidate: Boolean,
     val signatureMethod: String,


### PR DESCRIPTION
Received "id": 2263743456 doesn't fit into Int. Changing to Long.