### PR TITLE
[Improvement] Device management migrated from using API Keys to JWT tokens

### DIFF
--- a/app/src/main/java/no/nordicsemi/android/ei/repository/DevicesRepository.kt
+++ b/app/src/main/java/no/nordicsemi/android/ei/repository/DevicesRepository.kt
@@ -1,0 +1,64 @@
+package no.nordicsemi.android.ei.repository
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import no.nordicsemi.android.ei.di.IODispatcher
+import no.nordicsemi.android.ei.service.EiService
+import no.nordicsemi.android.ei.service.param.RenameDeviceRequest
+import javax.inject.Inject
+
+class DevicesRepository @Inject constructor(
+    private val service: EiService,
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher
+) {
+
+    /**
+     * List all devices for this project.
+     *
+     * Devices get included here if they connect to the remote management API or
+     * if they have sent data to the ingestion API and had the `device_id` field set.
+     */
+    suspend fun listDevices(token: String, projectId: Int) =
+        withContext(ioDispatcher) {
+            service.listDevices(jwt = token, projectId = projectId)
+        }
+
+    /**
+     * Set the current name for a device.
+     *
+     * @param name New name for this device.
+     */
+    suspend fun renameDevice(
+        token: String,
+        projectId: Int,
+        deviceId: String,
+        name: String
+    ) = withContext(ioDispatcher) {
+        service.renameDevice(
+            jwt = token,
+            projectId = projectId,
+            /*Encode thr url manually as retrofit does not correctly encode https://github.com/square/retrofit/issues/3080*/
+            deviceId = deviceId.replace(":", "%3A"),
+            renameDeviceRequest = RenameDeviceRequest(name = name)
+        )
+    }
+
+    /**
+     * Delete a device.
+     *
+     * When this device sends a new message to ingestion or connects to remote
+     * management the device will be recreated.
+     */
+    suspend fun deleteDevice(
+        token: String,
+        projectId: Int,
+        deviceId: String
+    ) = withContext(ioDispatcher) {
+        service.deleteDevice(
+            jwt = token,
+            projectId = projectId,
+            /*Encode thr url manually as retrofit does not correctly encode https://github.com/square/retrofit/issues/3080*/
+            deviceId = deviceId.replace(":", "%3A")
+        )
+    }
+}

--- a/app/src/main/java/no/nordicsemi/android/ei/repository/DevicesRepository.kt
+++ b/app/src/main/java/no/nordicsemi/android/ei/repository/DevicesRepository.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2026, Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package no.nordicsemi.android.ei.repository
 
 import kotlinx.coroutines.CoroutineDispatcher

--- a/app/src/main/java/no/nordicsemi/android/ei/repository/ProjectRepository.kt
+++ b/app/src/main/java/no/nordicsemi/android/ei/repository/ProjectRepository.kt
@@ -13,7 +13,6 @@ import no.nordicsemi.android.ei.model.Category
 import no.nordicsemi.android.ei.model.DevelopmentKeys
 import no.nordicsemi.android.ei.service.EiService
 import no.nordicsemi.android.ei.service.param.BuildOnDeviceModelRequest
-import no.nordicsemi.android.ei.service.param.RenameDeviceRequest
 import no.nordicsemi.android.ei.service.param.StartSamplingRequest
 import javax.inject.Inject
 
@@ -21,11 +20,6 @@ class ProjectRepository @Inject constructor(
     private val service: EiService,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ) {
-
-    suspend fun listDevices(projectId: Int, keys: DevelopmentKeys) =
-        withContext(ioDispatcher) {
-            service.listDevices(apiKey = keys.apiKey, projectId = projectId)
-        }
 
     suspend fun listSamples(
         projectId: Int,
@@ -95,34 +89,6 @@ class ProjectRepository @Inject constructor(
         service.downloadBuild(
             apiKey = keys.apiKey,
             projectId = projectId
-        )
-    }
-
-    suspend fun renameDevice(
-        apiKey: String,
-        projectId: Int,
-        deviceId: String,
-        name: String
-    ) = withContext(ioDispatcher) {
-        service.renameDevice(
-            apiKey = apiKey,
-            projectId = projectId,
-            /*Encode thr url manually as retrofit does not correctly encode https://github.com/square/retrofit/issues/3080*/
-            deviceId = deviceId.replace(":", "%3A"),
-            renameDeviceRequest = RenameDeviceRequest(name = name)
-        )
-    }
-
-    suspend fun deleteDevice(
-        apiKey: String,
-        projectId: Int,
-        deviceId: String
-    ) = withContext(ioDispatcher) {
-        service.deleteDevice(
-            apiKey = apiKey,
-            projectId = projectId,
-            /*Encode thr url manually as retrofit does not correctly encode https://github.com/square/retrofit/issues/3080*/
-            deviceId = deviceId.replace(":", "%3A")
         )
     }
 }

--- a/app/src/main/java/no/nordicsemi/android/ei/service/EiService.kt
+++ b/app/src/main/java/no/nordicsemi/android/ei/service/EiService.kt
@@ -100,20 +100,20 @@ interface EiService {
      * here if they connect to the remote management API or if they have sent data to the ingestion API
      * and had the device_id field set.
      *
-     * @param apiKey       Token received during the login.
+     * @param jwt       Token received during the login.
      * @param projectId Project ID.
      */
     @Headers("Accept: application/json", "Content-Type: application/json")
     @GET("api/{projectId}/devices")
     suspend fun listDevices(
-        @Header("x-api-key") apiKey: String,
+        @Header("x-jwt-token") jwt: String,
         @Path("projectId") projectId: Int
     ): ListDevicesResponse
 
     /**
      * Sets the current name for a device.
      *
-     * @param apiKey                Token received during the login.
+     * @param jwt                   Token received during the login.
      * @param projectId             Project ID.
      * @param deviceId              Device ID
      * @param renameDeviceRequest   Device rename request parameters
@@ -121,7 +121,7 @@ interface EiService {
     @Headers("Accept: application/json", "Content-Type: application/json")
     @POST("api/{projectId}/devices/{deviceId}/rename")
     suspend fun renameDevice(
-        @Header("x-api-key") apiKey: String,
+        @Header("x-jwt-token") jwt: String,
         @Path("projectId") projectId: Int,
         //Set value as encoded already as retrofit seem to encode colons with %253A instead of %3A
         @Path("deviceId", encoded = true) deviceId: String,
@@ -131,14 +131,14 @@ interface EiService {
     /**
      * Deletes a device
      *
-     * @param apiKey                Token received during the login.
+     * @param jwt                   Token received during the login.
      * @param projectId             Project ID.
      * @param deviceId              Device ID.
      */
     @Headers("Accept: application/json", "Content-Type: application/json")
     @DELETE("api/{projectId}/device/{deviceId}")
     suspend fun deleteDevice(
-        @Header("x-api-key") apiKey: String,
+        @Header("x-jwt-token") jwt: String,
         @Path("projectId") projectId: Int,
         //Set value as encoded already as retrofit seem to encode colons with %253A instead of %3A
         @Path("deviceId", encoded = true) deviceId: String
@@ -162,7 +162,7 @@ interface EiService {
      * Retrieve all the samples for a project.
      *
      * @param apiKey       Token received during the login.
-     * @param projectId Project ID.
+     * @param projectId    Project ID.
      */
     @Headers("Accept: application/json", "Content-Type: application/json")
     @GET("api/{projectId}/raw-data")

--- a/app/src/main/java/no/nordicsemi/android/ei/viewmodels/ProjectViewModel.kt
+++ b/app/src/main/java/no/nordicsemi/android/ei/viewmodels/ProjectViewModel.kt
@@ -68,8 +68,10 @@ import no.nordicsemi.android.ei.model.Device
 import no.nordicsemi.android.ei.model.InferencingMessage.InferencingRequest
 import no.nordicsemi.android.ei.model.Message.Sample
 import no.nordicsemi.android.ei.model.Sensor
+import no.nordicsemi.android.ei.repository.DevicesRepository
 import no.nordicsemi.android.ei.repository.ProjectDataRepository
 import no.nordicsemi.android.ei.repository.ProjectRepository
+import no.nordicsemi.android.ei.repository.UserDataRepository
 import no.nordicsemi.android.ei.util.ZipPackage
 import no.nordicsemi.android.ei.util.guard
 import no.nordicsemi.android.ei.viewmodels.event.Event
@@ -84,6 +86,7 @@ class ProjectViewModel @Inject constructor(
     @ApplicationContext context: Context,
     private val userManager: UserManager,
     private val projectRepository: ProjectRepository,
+    private val devicesRepository: DevicesRepository,
     private val client: OkHttpClient,
     private val gson: Gson
 ) : AndroidViewModel(context as Application), FirmwareUpgradeCallback<FirmwareUpgradeManager.State> {
@@ -99,6 +102,9 @@ class ProjectViewModel @Inject constructor(
 
     private val projectManager: ProjectManager
         get() = userComponentEntryPoint.getProjectManager()
+
+    private val userDataManager: UserDataRepository
+        get() = userComponentEntryPoint.userDataRepository()
 
     private val projectDataRepository: ProjectDataRepository
         get() = EntryPoints
@@ -260,9 +266,9 @@ class ProjectViewModel @Inject constructor(
             }
         }
         viewModelScope.launch(handler) {
-            projectRepository.listDevices(
+            devicesRepository.listDevices(
+                token = userDataManager.token,
                 projectId = projectDataRepository.project.id,
-                keys = projectDataRepository.developmentKeys
             ).let { response ->
                 guard(response.success) {
                     throw Throwable(response.error)
@@ -646,8 +652,8 @@ class ProjectViewModel @Inject constructor(
                     .also { isDeviceRenameRequested = false }
             }
         }) {
-            projectRepository.renameDevice(
-                apiKey = keys.apiKey,
+            devicesRepository.renameDevice(
+                token = userDataManager.token,
                 projectId = project.id,
                 deviceId = device.deviceId,
                 name = name
@@ -672,8 +678,8 @@ class ProjectViewModel @Inject constructor(
                     .also { isDeviceRenameRequested = false }
             }
         }) {
-            projectRepository.deleteDevice(
-                apiKey = keys.apiKey,
+            devicesRepository.deleteDevice(
+                token = userDataManager.token,
                 projectId = project.id,
                 deviceId = device.deviceId
             ).let { response ->


### PR DESCRIPTION
Previously, the devices were managed (listed, renamed, deleted) using the Development Key, but as the Dev Key has Roles (https://docs.edgeimpulse.com/studio/projects/dashboard/api-keys), and only the "admin" type would work, this PR switches this to JWT tokens instead. This seems to work at all time.